### PR TITLE
Better error reporting for browserify

### DIFF
--- a/config.js
+++ b/config.js
@@ -126,9 +126,12 @@ module.exports = {
       } else if (err.lineNumber) {
         message += ' at line ' + chalk.bold(err.lineNumber);
       }
-
-      console.log(message);
-      console.log(chalk.red(err.message));
+       if(plugin == "browserify") {
+        console.log(err);
+      } else {
+        console.log(message);
+        console.log(chalk.red(err.message));
+      }
     }
   },
   rename: {


### PR DESCRIPTION
When you get an error using browserify with the current config you get something akin to the following:

ParseError: Unexpected token .

this fix changes this to something more along the lines of 

/Users/reubendoetsch/recombine/orginal-labs/src/scripts/ng-app/services/recombine_api_service.js:15
      Restangular..setDefaultHttpFields({withCredentials: true});

which is massively helpful for debugging these sort of errors.

I checked other browserify errors and they all work as intended.
