### PR TITLE
Use a livereload port specified in default settings

### DIFF
--- a/config.js
+++ b/config.js
@@ -108,7 +108,8 @@ module.exports = {
   },
   livereload: {
     /* Reload page in browser when build is finished */
-    enabled: true
+    enabled: true,
+    port: 35729
   },
   newer: {
     /* Process only changed files */

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = function(gulp, userConfig) {
 
   // start livereload server early
   if (isPluginEnabled('livereload'))
-    $.livereload.listen();
+    $.livereload.listen(config.livereload.port);
 
   var cdn = config.substituter.cdn || '';
   // setup gulp-substituter js and css keys
@@ -250,16 +250,21 @@ module.exports = function(gulp, userConfig) {
     ], ['index']);
 
     if (isPluginEnabled('livereload')) {
-      $.livereload.listen();
+      var server = $.livereload.listen(config.livereload.port);
 
-      gulp.watch(path.join(config.dist.markupDir, config.dist.markupFiles), $.livereload.changed);
+      var onChange = function(e) {
+        $.livereload.changed(e.path, server);
+      };
+
+      gulp.watch(path.join(config.dist.markupDir, config.dist.markupFiles))
+        .on("change", onChange);
 
       if (!isPluginEnabled('rename')) {
         // markup is not changed when rename is disabled, we can livereload
         gulp.watch([
           path.join(config.dist.scriptDir, config.dist.scriptFiles),
           path.join(config.dist.styleDir, config.dist.styleFiles)
-        ], $.livereload.changed);
+        ]).on("change", onChange);
       }
     }
   });


### PR DESCRIPTION
This change allows running livereload on a different port, for when multiple live-reload servers could be running.
